### PR TITLE
Fix caching issue with signing key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jill64/cf-auth0",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jill64/cf-auth0.git",
-    "image": "https://opengraph.githubassets.com/abf878c8c5f09cdb4561e52802a511f070267fbfd66ceb030df236964c42c428/jill64/cf-auth0"
+    "image": "https://opengraph.githubassets.com/90f46836c4dfa9ecfd078db55299c764f9f0e6a201e5ea22ca1f8a20ff355a70/jill64/cf-auth0"
   },
   "description": "Auth0 on Cloudflare Pages",
   "publishConfig": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,17 +28,28 @@ export const CfAuth0 = ({
 
     console.log('debug:1')
 
-    client.getSigningKey(header.kid)
+    client.getSigningKey(
+      header.kid,
+      (key: {
+        alg?: unknown
+        kid?: unknown
+        publicKey: string
+        rsaPublicKey: string
+        getPublicKey: () => string
+      }) => {
+        console.log('debug:3')
 
-    console.log('debug:3')
+        if (cached_key) {
+          callback(null, cached_key)
+        }
 
-    if (cached_key) {
-      callback(null, cached_key)
-    }
+        const signingKey = key?.getPublicKey()
+        cached_key = signingKey
+        callback(null, signingKey)
+      }
+    )
 
-    // const signingKey = key?.getPublicKey()
-    // cached_key = signingKey
-    callback(null, 'signingKey')
+    console.log('debug:2')
   }
 
   const verifyToken = (token: string): Promise<jwt.JwtPayload | string> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export const CfAuth0 = ({
 
         if (cached_key) {
           callback(null, cached_key)
+          return
         }
 
         const signingKey = key?.getPublicKey()

--- a/src/jwks-rsa/esm/src/JwksClient.js
+++ b/src/jwks-rsa/esm/src/JwksClient.js
@@ -75,7 +75,7 @@ class JwksClient {
   }
 
   // @ts-expect-error TODO
-  async getSigningKey(kid) {
+  async getSigningKey(kid, cb) {
     logger(`Fetching signing key for '${kid}'`)
 
     const keys = await this.getSigningKeys()
@@ -93,7 +93,7 @@ class JwksClient {
       // eslint-disable-next-line no-undef
       console.log('Determined Key:', key)
 
-      // cb(key)
+      cb(key)
     } else {
       logger(`Unable to find a signing key that matches '${kid}'`)
       throw new SigningKeyNotFoundError(


### PR DESCRIPTION
This pull request includes a fix for an issue with caching the signing key in CfAuth0. The commit "Revert 'Refactor getSigningKey function in index.ts and JwksClient.js'" reverts a previous commit. The commit "chore: synchronize README.md" synchronizes the README.md file. The patch shows changes made to the "repository" field in package.json. The patch also shows changes made to the getSigningKey function in index.ts and JwksClient.js, fixing the caching issue.