### PR TITLE
Refactor toString function and export statements in jws/esm/index.ts and jws/esm/lib/verify-stream.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jill64/cf-auth0",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jill64/cf-auth0.git",
-    "image": "https://opengraph.githubassets.com/8c5f39b82b7e6f3d8237bcb5ef61f88859f966c80ab399ec027f3ec0d4c1d573/jill64/cf-auth0"
+    "image": "https://opengraph.githubassets.com/a53462d408167500fceb79cba46c22adf84bcd14c0b8edfc49f6fd4f1bd804e6/jill64/cf-auth0"
   },
   "description": "Auth0 on Cloudflare Pages",
   "publishConfig": {

--- a/src/jws/esm/index.ts
+++ b/src/jws/esm/index.ts
@@ -1,5 +1,5 @@
 import SignStream from './lib/sign-stream.js'
-import VerifyStream from './lib/verify-stream.js'
+export { verify, decode, isValid } from './lib/verify-stream.js'
 
 export const ALGORITHMS = [
   'HS256',
@@ -17,16 +17,8 @@ export const ALGORITHMS = [
 ]
 
 export const sign = SignStream.sign
-export const verify = VerifyStream.verify
-export const decode = VerifyStream.decode
-export const isValid = VerifyStream.isValid
 // @ts-expect-error TODO
 export const createSign = function createSign(opts) {
   // @ts-expect-error TODO
   return new SignStream(opts)
-}
-// @ts-expect-error TODO
-export const createVerify = function createVerify(opts) {
-  // @ts-expect-error TODO
-  return new VerifyStream(opts)
 }

--- a/src/jws/esm/lib/tostring.ts
+++ b/src/jws/esm/lib/tostring.ts
@@ -1,7 +1,6 @@
 import { Buffer } from 'node:buffer'
 
-// @ts-expect-error TODO
-export default function toString(obj) {
+export default function toString(obj: unknown) {
   if (typeof obj === 'string') return obj
   if (typeof obj === 'number' || Buffer.isBuffer(obj)) return obj.toString()
   return JSON.stringify(obj)

--- a/src/jws/esm/lib/verify-stream.ts
+++ b/src/jws/esm/lib/verify-stream.ts
@@ -1,10 +1,8 @@
 import { Buffer } from 'node:buffer'
-import Stream from 'node:stream'
-import util from 'node:util'
 import jwa from '../../../jwa/esm/index.js'
-import DataStream from './data-stream.js'
 import toString from './tostring.js'
-var JWS_REGEX = /^[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+?\.([a-zA-Z0-9\-_]+)?$/
+
+const JWS_REGEX = /^[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+?\.([a-zA-Z0-9\-_]+)?$/
 
 // @ts-expect-error TODO
 function isObject(thing) {
@@ -87,65 +85,6 @@ function jwsDecode(jwsSig, opts) {
   }
 }
 
-// @ts-expect-error TODO
-function VerifyStream(opts) {
-  opts = opts || {}
-  var secretOrKey = opts.secret || opts.publicKey || opts.key
-  // @ts-expect-error TODO
-  var secretStream = new DataStream(secretOrKey)
-  // @ts-expect-error TODO
-  this.readable = true
-  // @ts-expect-error TODO
-  this.algorithm = opts.algorithm
-  // @ts-expect-error TODO
-  this.encoding = opts.encoding
-  // @ts-expect-error TODO
-  this.secret = this.publicKey = this.key = secretStream
-  // @ts-expect-error TODO
-  this.signature = new DataStream(opts.signature)
-  // @ts-expect-error TODO
-  this.secret.once(
-    'close',
-    function () {
-      // @ts-expect-error TODO
-      if (!this.signature.writable && this.readable) this.verify()
-      // @ts-expect-error TODO
-    }.bind(this)
-  )
-
-  // @ts-expect-error TODO
-  this.signature.once(
-    'close',
-    function () {
-      // @ts-expect-error TODO
-      if (!this.secret.writable && this.readable) this.verify()
-      // @ts-expect-error TODO
-    }.bind(this)
-  )
-}
-util.inherits(VerifyStream, Stream)
-VerifyStream.prototype.verify = function verify() {
-  try {
-    var valid = jwsVerify(
-      this.signature.buffer,
-      this.algorithm,
-      this.key.buffer
-    )
-    var obj = jwsDecode(this.signature.buffer, this.encoding)
-    this.emit('done', valid, obj)
-    this.emit('data', valid)
-    this.emit('end')
-    this.readable = false
-    return valid
-  } catch (e) {
-    this.readable = false
-    this.emit('error', e)
-    this.emit('close')
-  }
-}
-
-VerifyStream.decode = jwsDecode
-VerifyStream.isValid = isValidJws
-VerifyStream.verify = jwsVerify
-
-export default VerifyStream
+export const decode = jwsDecode
+export const isValid = isValidJws
+export const verify = jwsVerify


### PR DESCRIPTION
Refactor the `toString` function in `jws/esm/lib/tostring.js` to use TypeScript type annotations. Additionally, refactor the export statements in `jws/esm/index.ts` and `jws/esm/lib/verify-stream.ts` to improve code organization and remove unnecessary code. These changes enhance the readability and maintainability of the codebase.