### PR TITLE
Simplify and refactor jwks-rsa

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jill64/cf-auth0.git",
-    "image": "https://opengraph.githubassets.com/1769832a960cd3ea12d66f2ee0d677b91f5ac8faf9a39713d2aaea518be92941/jill64/cf-auth0"
+    "image": "https://opengraph.githubassets.com/eee8c9a490ed9ae10287d2bf9e07efd7a4fa834de6a22c3acfaad3933465a6ff/jill64/cf-auth0"
   },
   "description": "Auth0 on Cloudflare Pages",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jill64/cf-auth0",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/jose/esm/src/key/export.ts
+++ b/src/jose/esm/src/key/export.ts
@@ -1,6 +1,4 @@
 import { toSPKI as exportPublic } from '../runtime/browser/asn1.js'
 import type { KeyLike } from '../types.d.ts'
 
-export async function exportSPKI(key: KeyLike): Promise<string> {
-  return exportPublic(key)
-}
+export const exportSPKI = (key: KeyLike) => exportPublic(key)

--- a/src/jose/esm/src/runtime/browser/asn1.ts
+++ b/src/jose/esm/src/runtime/browser/asn1.ts
@@ -28,6 +28,5 @@ const genericExport = async (
   )
 }
 
-export const toSPKI: PEMExportFunction = (key) => {
-  return genericExport('public', 'spki', key)
-}
+export const toSPKI: PEMExportFunction = (key) =>
+  genericExport('public', 'spki', key)

--- a/src/jwks-rsa/esm/src/utils.ts
+++ b/src/jwks-rsa/esm/src/utils.ts
@@ -54,23 +54,16 @@ const retrieveSigningKeys = async (jwks: JWK[]) => {
         continue
       }
 
-      let getSpki
-
       // @ts-expect-error TODO
-      switch (key[Symbol.toStringTag]) {
-        case 'CryptoKey': {
-          const spki = await exportSPKI(key)
-          getSpki = () => spki
-          break
-        }
-        case 'KeyObject':
-        // Assume legacy Node.js version without the Symbol.toStringTag backported
-        // Fall through
-        default:
-          // getSpki = () => key.export({ format: 'pem', type: 'spki' })
-          const spki = await exportSPKI(key)
-          getSpki = () => spki
+      const keyTag: unknown = key[Symbol.toStringTag]
+
+      if (keyTag !== 'CryptoKey' && keyTag !== 'KeyObject') {
+        throw new JwksError('Unsupported key type')
       }
+
+      const spki = await exportSPKI(key)
+      const getSpki = () => spki
+
       results.push({
         get publicKey() {
           return getSpki()


### PR DESCRIPTION
This pull request simplifies and refactors the jwks-rsa module. The `exportSPKI` function has been converted to an arrow function for improved readability. Additionally, the `toSPKI` function has been simplified by removing unnecessary code. The `retrieveSigningKeys` function has been updated to handle unsupported key types and now throws a `JwksError` when encountered. These changes improve the overall code structure and maintainability of the jwks-rsa module.