### PR TITLE
Refactor error message, key export functions, and setAuthCookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jill64/cf-auth0",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jill64/cf-auth0.git",
-    "image": "https://opengraph.githubassets.com/da3818a6353822a82c2b81b3889a915a443ef43cf471a952824b89f0614631e2/jill64/cf-auth0"
+    "image": "https://opengraph.githubassets.com/6c347c6d8d21f94532ea7146ed0509b19057ba438d19f04ddba7b15b9b521ac4/jill64/cf-auth0"
   },
   "description": "Auth0 on Cloudflare Pages",
   "publishConfig": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,10 @@ export const CfAuth0 = ({
 
   const verify = jwt.verify
 
-  const setAuthCookie = (cookies: Cookies, user: jwt.JwtPayload | string) => {
+  const setAuthCookie = async (
+    cookies: Cookies,
+    user: jwt.JwtPayload | string
+  ) => {
     // @ts-expect-error TODO
     const cookieValue = await jwt.sign(user, session_secret)
     cookies.set(auth0_cookie_name, cookieValue, {

--- a/src/jwa/esm/index.ts
+++ b/src/jwa/esm/index.ts
@@ -28,7 +28,7 @@ let MSG_INVALID_VERIFIER_KEY = 'key must be a string or a buffer'
 const MSG_INVALID_SIGNER_KEY = 'key must be a string, a buffer or an object'
 
 MSG_INVALID_VERIFIER_KEY += ' or a KeyObject'
-MSG_INVALID_SECRET += 'or a KeyObject'
+MSG_INVALID_SECRET += ' or a KeyObject'
 
 const checkIsPublicKey = (key: unknown) => {
   if (Buffer.isBuffer(key)) {

--- a/src/jwa/esm/index.ts
+++ b/src/jwa/esm/index.ts
@@ -54,7 +54,7 @@ const checkIsPublicKey = (key: unknown) => {
   }
 
   // @ts-expect-error TODO
-  if (typeof key.exports !== 'function') {
+  if (typeof key.export !== 'function') {
     throw typeError(MSG_INVALID_VERIFIER_KEY)
   }
 }
@@ -94,7 +94,7 @@ const checkIsSecretKey = (key: unknown) => {
   }
 
   // @ts-expect-error TODO
-  if (typeof key.exports !== 'function') {
+  if (typeof key.export !== 'function') {
     throw typeError(MSG_INVALID_SECRET)
   }
 }

--- a/src/lib/crypto/KeyObjectLike.ts
+++ b/src/lib/crypto/KeyObjectLike.ts
@@ -60,11 +60,11 @@ class KeyObjectLike {
     }
   }
 
-  exports(options: KeyExportOptions<'pem'>): string | Buffer
-  exports(options?: KeyExportOptions<'der'>): Buffer
-  exports(options?: JwkKeyExportOptions): JsonWebKey
+  export(options: KeyExportOptions<'pem'>): string | Buffer
+  export(options?: KeyExportOptions<'der'>): Buffer
+  export(options?: JwkKeyExportOptions): JsonWebKey
 
-  exports(
+  export(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     options?:
       | KeyExportOptions<'pem'>

--- a/src/lib/crypto/isKeyObjectLike.ts
+++ b/src/lib/crypto/isKeyObjectLike.ts
@@ -10,5 +10,5 @@ export const isKeyObjectLike = (val: unknown): val is KeyObjectLike =>
   typeof val.from === 'function' &&
   'equals' in val &&
   typeof val.equals === 'function' &&
-  'exports' in val &&
-  typeof val.exports === 'function'
+  'export' in val &&
+  typeof val.export === 'function'


### PR DESCRIPTION
The commits in this pull request refactor the error message in `jwa/esm/index.ts`, update the key export functions to use "export" instead of "exports", and refactor the `setAuthCookie` function to be asynchronous. These changes improve the code readability and maintainability.