### PR TITLE
Implement KeyObject and related functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jill64/cf-auth0.git",
-    "image": "https://opengraph.githubassets.com/00c8c816680f8e0a62053656b8a91a7bd9ef10fd61336846ede225c774f353fc/jill64/cf-auth0"
+    "image": "https://opengraph.githubassets.com/89ea3390e9d0af38b886b1e89b8ca1e86f6571112d5ac41684fbd2f503628a17/jill64/cf-auth0"
   },
   "description": "Auth0 on Cloudflare Pages",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jill64/cf-auth0",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/jose/esm/src/runtime/browser/asn1.ts
+++ b/src/jose/esm/src/runtime/browser/asn1.ts
@@ -1,9 +1,12 @@
-import { isCryptoKey, subtle } from '../../../../../lib/crypto/index.js'
+import { isCryptoKey } from '../../../../../lib/crypto/index.js'
 import formatPEM from '../../lib/format_pem.js'
 import invalidKeyInput from '../../lib/invalid_key_input.js'
-import type { PEMExportFunction } from '../interfaces.d.ts'
-import { encodeBase64 } from './base64url.js'
+import { JOSENotSupported } from '../../util/errors.js'
+import { decodeBase64, encodeBase64 } from './base64url.js'
+import type { PEMExportFunction, PEMImportFunction } from './interfaces.d.ts'
 import { types } from './is_key_like.js'
+
+import type { PEMImportOptions } from '../../key/import.js'
 
 const genericExport = async (
   keyType: 'private' | 'public',
@@ -23,10 +26,251 @@ const genericExport = async (
   }
 
   return formatPEM(
-    encodeBase64(new Uint8Array(await subtle.exportKey(keyFormat, key))),
+    encodeBase64(new Uint8Array(await crypto.subtle.exportKey(keyFormat, key))),
     `${keyType.toUpperCase()} KEY`
   )
 }
 
-export const toSPKI: PEMExportFunction = (key) =>
-  genericExport('public', 'spki', key)
+export const toSPKI: PEMExportFunction = (key) => {
+  return genericExport('public', 'spki', key)
+}
+
+export const toPKCS8: PEMExportFunction = (key) => {
+  return genericExport('private', 'pkcs8', key)
+}
+
+const findOid = (keyData: Uint8Array, oid: number[], from = 0): boolean => {
+  if (from === 0) {
+    oid.unshift(oid.length)
+    oid.unshift(0x06)
+  }
+  const i = keyData.indexOf(oid[0], from)
+  if (i === -1) return false
+  const sub = keyData.subarray(i, i + oid.length)
+  if (sub.length !== oid.length) return false
+  return (
+    sub.every((value, index) => value === oid[index]) ||
+    findOid(keyData, oid, i + 1)
+  )
+}
+
+const getNamedCurve = (keyData: Uint8Array): string => {
+  switch (true) {
+    case findOid(keyData, [0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07]):
+      return 'P-256'
+    case findOid(keyData, [0x2b, 0x81, 0x04, 0x00, 0x22]):
+      return 'P-384'
+    case findOid(keyData, [0x2b, 0x81, 0x04, 0x00, 0x23]):
+      return 'P-521'
+    case findOid(keyData, [0x2b, 0x65, 0x6e]):
+      return 'X25519'
+    case findOid(keyData, [0x2b, 0x65, 0x6f]):
+      return 'X448'
+    case findOid(keyData, [0x2b, 0x65, 0x70]):
+      return 'Ed25519'
+    case findOid(keyData, [0x2b, 0x65, 0x71]):
+      return 'Ed448'
+    default:
+      throw new JOSENotSupported(
+        'Invalid or unsupported EC Key Curve or OKP Key Sub Type'
+      )
+  }
+}
+
+const genericImport = async (
+  replace: RegExp,
+  keyFormat: 'spki' | 'pkcs8',
+  pem: string,
+  alg: string,
+  options?: PEMImportOptions
+) => {
+  let algorithm: RsaHashedImportParams | EcKeyAlgorithm | Algorithm
+  let keyUsages: KeyUsage[]
+
+  const keyData = new Uint8Array(
+    atob(pem.replace(replace, ''))
+      .split('')
+      .map((c) => c.charCodeAt(0))
+  )
+
+  const isPublic = keyFormat === 'spki'
+
+  switch (alg) {
+    case 'PS256':
+    case 'PS384':
+    case 'PS512':
+      algorithm = { name: 'RSA-PSS', hash: `SHA-${alg.slice(-3)}` }
+      keyUsages = isPublic ? ['verify'] : ['sign']
+      break
+    case 'RS256':
+    case 'RS384':
+    case 'RS512':
+      algorithm = { name: 'RSASSA-PKCS1-v1_5', hash: `SHA-${alg.slice(-3)}` }
+      keyUsages = isPublic ? ['verify'] : ['sign']
+      break
+    case 'RSA-OAEP':
+    case 'RSA-OAEP-256':
+    case 'RSA-OAEP-384':
+    case 'RSA-OAEP-512':
+      algorithm = {
+        name: 'RSA-OAEP',
+        hash: `SHA-${parseInt(alg.slice(-3), 10) || 1}`
+      }
+      keyUsages = isPublic ? ['encrypt', 'wrapKey'] : ['decrypt', 'unwrapKey']
+      break
+    case 'ES256':
+      algorithm = { name: 'ECDSA', namedCurve: 'P-256' }
+      keyUsages = isPublic ? ['verify'] : ['sign']
+      break
+    case 'ES384':
+      algorithm = { name: 'ECDSA', namedCurve: 'P-384' }
+      keyUsages = isPublic ? ['verify'] : ['sign']
+      break
+    case 'ES512':
+      algorithm = { name: 'ECDSA', namedCurve: 'P-521' }
+      keyUsages = isPublic ? ['verify'] : ['sign']
+      break
+    case 'ECDH-ES':
+    case 'ECDH-ES+A128KW':
+    case 'ECDH-ES+A192KW':
+    case 'ECDH-ES+A256KW': {
+      const namedCurve = getNamedCurve(keyData)
+      algorithm = namedCurve.startsWith('P-')
+        ? { name: 'ECDH', namedCurve }
+        : { name: namedCurve }
+      keyUsages = isPublic ? [] : ['deriveBits']
+      break
+    }
+    case 'EdDSA':
+      algorithm = { name: getNamedCurve(keyData) }
+      keyUsages = isPublic ? ['verify'] : ['sign']
+      break
+    default:
+      throw new JOSENotSupported(
+        'Invalid or unsupported "alg" (Algorithm) value'
+      )
+  }
+
+  return crypto.subtle.importKey(
+    keyFormat,
+    keyData,
+    algorithm,
+    options?.extractable ?? false,
+    keyUsages
+  )
+}
+
+export const fromPKCS8: PEMImportFunction = (pem, alg, options?) => {
+  return genericImport(
+    /(?:-----(?:BEGIN|END) PRIVATE KEY-----|\s)/g,
+    'pkcs8',
+    pem,
+    alg,
+    options
+  )
+}
+
+export const fromSPKI: PEMImportFunction = (pem, alg, options?) => {
+  return genericImport(
+    /(?:-----(?:BEGIN|END) PUBLIC KEY-----|\s)/g,
+    'spki',
+    pem,
+    alg,
+    options
+  )
+}
+
+function getElement(seq: Uint8Array) {
+  const result = []
+  let next = 0
+
+  while (next < seq.length) {
+    const nextPart = parseElement(seq.subarray(next))
+    result.push(nextPart)
+    next += nextPart.byteLength
+  }
+  return result
+}
+
+export function parseElement(bytes: Uint8Array) {
+  let position = 0
+
+  // tag
+  let tag = bytes[0] & 0x1f
+  position++
+  if (tag === 0x1f) {
+    tag = 0
+    while (bytes[position] >= 0x80) {
+      tag = tag * 128 + bytes[position] - 0x80
+      position++
+    }
+    tag = tag * 128 + bytes[position] - 0x80
+    position++
+  }
+
+  // length
+  let length = 0
+  if (bytes[position] < 0x80) {
+    length = bytes[position]
+    position++
+  } else if (length === 0x80) {
+    length = 0
+
+    while (
+      bytes[position + length] !== 0 ||
+      bytes[position + length + 1] !== 0
+    ) {
+      if (length > bytes.byteLength) {
+        throw new TypeError('invalid indefinite form length')
+      }
+      length++
+    }
+
+    const byteLength = position + length + 2
+    return {
+      byteLength,
+      contents: bytes.subarray(position, position + length),
+      raw: bytes.subarray(0, byteLength)
+    }
+  } else {
+    const numberOfDigits = bytes[position] & 0x7f
+    position++
+    length = 0
+    for (let i = 0; i < numberOfDigits; i++) {
+      length = length * 256 + bytes[position]
+      position++
+    }
+  }
+
+  const byteLength = position + length
+  return {
+    byteLength,
+    contents: bytes.subarray(position, byteLength),
+    raw: bytes.subarray(0, byteLength)
+  }
+}
+
+function spkiFromX509(buf: Uint8Array) {
+  const tbsCertificate = getElement(
+    getElement(parseElement(buf).contents)[0].contents
+  )
+  return encodeBase64(
+    tbsCertificate[tbsCertificate[0].raw[0] === 0xa0 ? 6 : 5].raw
+  )
+}
+
+function getSPKI(x509: string): string {
+  const pem = x509.replace(/(?:-----(?:BEGIN|END) CERTIFICATE-----|\s)/g, '')
+  const raw = decodeBase64(pem)
+  return formatPEM(spkiFromX509(raw), 'PUBLIC KEY')
+}
+
+export const fromX509: PEMImportFunction = (pem, alg, options?) => {
+  let spki: string
+  try {
+    spki = getSPKI(pem)
+  } catch (cause) {
+    throw new TypeError('Failed to parse the X.509 certificate', { cause })
+  }
+  return fromSPKI(spki, alg, options)
+}

--- a/src/jose/esm/src/runtime/browser/interfaces.d.ts
+++ b/src/jose/esm/src/runtime/browser/interfaces.d.ts
@@ -1,0 +1,99 @@
+import type { JWK, KeyLike } from '../types.d'
+import type { PEMImportOptions } from '../key/import.js'
+
+type AsyncOrSync<T> = Promise<T> | T
+
+export interface TimingSafeEqual {
+  (a: Uint8Array, b: Uint8Array): boolean
+}
+export interface SignFunction {
+  (alg: string, key: unknown, data: Uint8Array): Promise<Uint8Array>
+}
+export interface VerifyFunction {
+  (
+    alg: string,
+    key: unknown,
+    signature: Uint8Array,
+    data: Uint8Array
+  ): Promise<boolean>
+}
+export interface AesKwWrapFunction {
+  (alg: string, key: unknown, cek: Uint8Array): AsyncOrSync<Uint8Array>
+}
+export interface AesKwUnwrapFunction {
+  (alg: string, key: unknown, encryptedKey: Uint8Array): AsyncOrSync<Uint8Array>
+}
+export interface RsaEsEncryptFunction {
+  (alg: string, key: unknown, cek: Uint8Array): AsyncOrSync<Uint8Array>
+}
+export interface RsaEsDecryptFunction {
+  (alg: string, key: unknown, encryptedKey: Uint8Array): AsyncOrSync<Uint8Array>
+}
+export interface Pbes2KWEncryptFunction {
+  (
+    alg: string,
+    key: unknown,
+    cek: Uint8Array,
+    p2c?: number,
+    p2s?: Uint8Array
+  ): Promise<{
+    encryptedKey: Uint8Array
+    p2c: number
+    p2s: string
+  }>
+}
+export interface Pbes2KWDecryptFunction {
+  (
+    alg: string,
+    key: unknown,
+    encryptedKey: Uint8Array,
+    p2c: number,
+    p2s: Uint8Array
+  ): Promise<Uint8Array>
+}
+export interface EncryptFunction {
+  (
+    enc: string,
+    plaintext: Uint8Array,
+    cek: unknown,
+    iv: Uint8Array | undefined,
+    aad: Uint8Array
+  ): AsyncOrSync<{
+    ciphertext: Uint8Array
+    tag: Uint8Array | undefined
+    iv: Uint8Array | undefined
+  }>
+}
+export interface DecryptFunction {
+  (
+    enc: string,
+    cek: unknown,
+    ciphertext: Uint8Array,
+    iv: Uint8Array | undefined,
+    tag: Uint8Array | undefined,
+    additionalData: Uint8Array
+  ): AsyncOrSync<Uint8Array>
+}
+export interface FetchFunction {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (
+    url: URL,
+    timeout: number,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    options?: any
+  ): Promise<{ [propName: string]: unknown }>
+}
+export interface DigestFunction {
+  (
+    digest: 'sha256' | 'sha384' | 'sha512',
+    data: Uint8Array
+  ): AsyncOrSync<Uint8Array>
+}
+export interface PEMImportFunction {
+  (pem: string, alg: string, options?: PEMImportOptions): AsyncOrSync<KeyLike>
+}
+interface ExportFunction<T> {
+  (key: unknown): AsyncOrSync<T>
+}
+export type JWKExportFunction = ExportFunction<JWK>
+export type PEMExportFunction = ExportFunction<string>

--- a/src/jose/esm/src/runtime/browser/is_key_like.ts
+++ b/src/jose/esm/src/runtime/browser/is_key_like.ts
@@ -1,4 +1,5 @@
 import { isCryptoKey } from '../../../../../lib/crypto/index.js'
+import { isKeyObject } from '../../../../../lib/crypto/isKeyObject.js'
 import type { KeyLike } from '../../types.d.ts'
 
 export default (key: unknown): key is KeyLike => {
@@ -6,8 +7,7 @@ export default (key: unknown): key is KeyLike => {
     return true
   }
 
-  // @ts-expect-error TODO
-  return key?.[Symbol.toStringTag] === 'KeyObject'
+  return isKeyObject(key)
 }
 
 export const types = ['CryptoKey']

--- a/src/jwa/esm/index.ts
+++ b/src/jwa/esm/index.ts
@@ -44,19 +44,20 @@ const checkIsPublicKey = (key: unknown) => {
     throw typeError(MSG_INVALID_VERIFIER_KEY, 2, key)
   }
 
-  if (!('type' in key) || typeof key.type !== 'string') {
+  // @ts-expect-error TODO
+  if (typeof key.type !== 'string') {
     throw typeError(MSG_INVALID_VERIFIER_KEY, 3, key)
   }
 
-  // TODO
-  // if (
-  //   !('asymmetricKeyType' in key) ||
-  //   typeof key.asymmetricKeyType !== 'string'
-  // ) {
-  //   throw typeError(MSG_INVALID_VERIFIER_KEY, 4, key)
-  // }
+  if (
+    !('asymmetricKeyType' in key) ||
+    typeof key.asymmetricKeyType !== 'string'
+  ) {
+    throw typeError(MSG_INVALID_VERIFIER_KEY, 4, key)
+  }
 
-  if (!('export' in key) || typeof key.export !== 'function') {
+  // @ts-expect-error TODO
+  if (typeof key.export !== 'function') {
     throw typeError(MSG_INVALID_VERIFIER_KEY, 5, key)
   }
 }
@@ -94,11 +95,13 @@ const checkIsSecretKey = (key: unknown) => {
     throw typeError(MSG_INVALID_SECRET, 2, key)
   }
 
-  if (!('type' in key) || key.type !== 'secret') {
+  // @ts-expect-error TODO
+  if (key.type !== 'secret') {
     throw typeError(MSG_INVALID_SECRET, 3, key)
   }
 
-  if (!('export' in key) || typeof key.export !== 'function') {
+  // @ts-expect-error TODO
+  if (typeof key.export !== 'function') {
     throw typeError(MSG_INVALID_SECRET, 4, key)
   }
 }

--- a/src/jwks-rsa/esm/src/utils.ts
+++ b/src/jwks-rsa/esm/src/utils.ts
@@ -1,5 +1,7 @@
 import { exportSPKI, importJWK } from '../../../jose/esm/src/index.js'
 import { JWK } from '../../../jose/esm/src/types.js'
+import { isCryptoKey } from '../../../lib/crypto/isCryptoKey.js'
+import { isKeyObject } from '../../../lib/crypto/isKeyObject.js'
 import JwksError from './errors/JwksError.js'
 
 const resolveAlg = (jwk: JWK) => {
@@ -54,10 +56,7 @@ const retrieveSigningKeys = async (jwks: JWK[]) => {
         continue
       }
 
-      // @ts-expect-error TODO
-      const keyTag: unknown = key[Symbol.toStringTag]
-
-      if (keyTag !== 'CryptoKey' && keyTag !== 'KeyObject') {
+      if (!isCryptoKey(key) && !isKeyObject(key)) {
         throw new JwksError('Unsupported key type')
       }
 

--- a/src/lib/crypto/AsymmetricKeyDetails.ts
+++ b/src/lib/crypto/AsymmetricKeyDetails.ts
@@ -1,0 +1,21 @@
+export type AsymmetricKeyDetails =
+  | {
+      // DSA
+      modulusLength: number
+      divisorLength: number | undefined
+    }
+  | {
+      // RSA
+      modulusLength: number
+      publicExponent: bigint
+    }
+  | {
+      // RSA-PSS
+      hashAlgorithm: string
+      mgf1HashAlgorithm: string
+      saltLength: number
+    }
+  | {
+      // EC
+      namedCurve: string | undefined
+    }

--- a/src/lib/crypto/AsymmetricKeyType.ts
+++ b/src/lib/crypto/AsymmetricKeyType.ts
@@ -1,0 +1,3 @@
+import { KeyObject } from 'node:crypto'
+
+export type AsymmetricKeyType = KeyObject['asymmetricKeyType']

--- a/src/lib/crypto/KeyObject.ts
+++ b/src/lib/crypto/KeyObject.ts
@@ -1,84 +1,157 @@
-// import type {
-//   JwkKeyExportOptions,
-//   KeyExportOptions,
-//   KeyObject as KeyObjectType
-// } from 'node:crypto'
+import type {
+  JwkKeyExportOptions,
+  KeyExportOptions,
+  KeyObject as KeyObjectType
+} from 'node:crypto'
+import type { AsymmetricKeyDetails } from './AsymmetricKeyDetails.js'
+import type { AsymmetricKeyType } from './AsymmetricKeyType.js'
 
-// const kHandle = Symbol('kHandle')
+type KeyObjectParams = (
+  | {
+      asymmetricKeyType: AsymmetricKeyType
+      asymmetricKeySize: KeyObjectType['asymmetricKeySize']
+      asymmetricKeyDetails: AsymmetricKeyDetails
+    }
+  | {
+      symmetricKeySize: KeyObjectType['symmetricKeySize']
+    }
+) & {
+  preExportedKeys: {
+    pkcs1: {
+      pem: string | Buffer
+      der: Buffer
+    }
+    spki: {
+      pem: string | Buffer
+      der: Buffer
+    }
+    pkcs8: {
+      pem: string | Buffer
+      der: Buffer
+    }
+    sec1: {
+      pem: string | Buffer
+      der: Buffer
+    }
+    jwk: JsonWebKey
+  }
+}
 
-// class KeyObject {
-//   type: KeyType
-//   asymmetricKeyType?: KeyObjectType['asymmetricKeyType']
-//   asymmetricKeySize?: KeyObjectType['asymmetricKeySize']
-//   asymmetricKeyDetails?: KeyObjectType['asymmetricKeyDetails']
-//   symmetricKeySize?: KeyObjectType['symmetricKeySize']
+class KeyObject implements KeyObjectType {
+  type: KeyType
+  asymmetricKeyType?: AsymmetricKeyType
+  asymmetricKeySize?: KeyObjectType['asymmetricKeySize']
+  asymmetricKeyDetails?: KeyObjectType['asymmetricKeyDetails']
+  symmetricKeySize?: KeyObjectType['symmetricKeySize']
+  private params
 
-//   private constructor(key: CryptoKey) {
-//     const { type } = key
+  private constructor(key: CryptoKey, params: KeyObjectParams) {
+    this.type = key.type
+    this.params = params
 
-//     if (type !== 'secret' && type !== 'public' && type !== 'private')
-//       throw new Error(`ERR_INVALID_ARG_VALUE: type ${type}`)
+    if ('asymmetricKeyType' in params) {
+      this.asymmetricKeyType = params.asymmetricKeyType
+      this.asymmetricKeySize = params.asymmetricKeySize
+      this.asymmetricKeyDetails = params.asymmetricKeyDetails
+    } else {
+      this.symmetricKeySize = params.symmetricKeySize
+    }
 
-//     this.type = type
+    console.log('CryptoKey key: ', key)
+    console.log('KeyObject params: ', params)
+  }
 
-//     Object.defineProperty(this, kHandle, {
-//       // @ts-expect-error TODO
-//       __proto__: null,
-//       // TODO
-//       value: null,
-//       // value: handle
-//       enumerable: false,
-//       configurable: false,
-//       writable: false
-//     })
-//   }
+  static from = (key: CryptoKey, params: KeyObjectParams) =>
+    new KeyObject(key, params)
 
-//   static from = (key: CryptoKey) => new KeyObject(key)
+  equals(otherKeyObject: KeyObjectType) {
+    try {
+      Object.keys(otherKeyObject).forEach((key) => {
+        // @ts-expect-error TODO
+        if (this[key] !== otherKeyObject[key]) {
+          throw new Error('KeyObjects are not equal')
+        }
+      })
 
-//   equals(otherKeyObject: KeyObjectType) {
-//     try {
-//       Object.keys(otherKeyObject).forEach((key) => {
-//         // @ts-expect-error TODO
-//         if (this[key] !== otherKeyObject[key]) {
-//           throw new Error('Key objects are not equal')
-//         }
-//       })
+      return true
+    } catch {
+      return false
+    }
+  }
 
-//       return (
-//         otherKeyObject.type === this.type &&
-//         // @ts-expect-error TODO
-//         this[kHandle].equals(otherKeyObject[kHandle])
-//       )
-//     } catch {
-//       return false
-//     }
-//   }
+  // @ts-expect-error TODO
+  export(options: KeyExportOptions<'pem'>): string | Buffer
+  // @ts-expect-error TODO
+  export(options?: KeyExportOptions<'der'>): Buffer
+  // @ts-expect-error TODO
+  export(options?: JwkKeyExportOptions): JsonWebKey
 
-//   export(options: KeyExportOptions<'pem'>): string | Buffer
-//   export(options?: KeyExportOptions<'der'>): Buffer
-//   export(options?: JwkKeyExportOptions): JsonWebKey
+  // @ts-expect-error TODO
+  export(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    options?:
+      | KeyExportOptions<'pem'>
+      | KeyExportOptions<'der'>
+      | JwkKeyExportOptions
+  ): string | Buffer | JsonWebKey {
+    if (options?.format === 'jwk' && this.params) {
+      return this.params.preExportedKeys.jwk
+    }
 
-//   export(
-//     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-//     options?:
-//       | KeyExportOptions<'pem'>
-//       | KeyExportOptions<'der'>
-//       | JwkKeyExportOptions
-//   ): string | Buffer | JsonWebKey {
-//     // TODO
-//     return ''
-//   }
-// }
+    if (options?.format === 'pem') {
+      switch (options.type) {
+        case 'spki':
+          if (this.params.preExportedKeys) {
+            return this.params.preExportedKeys.spki.pem
+          }
+          break
+        case 'pkcs8':
+          if (this.params.preExportedKeys) {
+            return this.params.preExportedKeys.pkcs8.pem
+          }
+          break
+        case 'sec1':
+          if (this.params.preExportedKeys) {
+            return this.params.preExportedKeys.sec1.pem
+          }
+          break
+        case 'pkcs1':
+          if (this.params.preExportedKeys) {
+            return this.params.preExportedKeys.pkcs1.pem
+          }
+        default:
+          throw new Error('Unsupported export type')
+      }
+    }
 
-// Object.defineProperties(KeyObject.prototype, {
-//   [Symbol.toStringTag]: {
-//     // @ts-expect-error TODO
-//     __proto__: null,
-//     configurable: true,
-//     value: 'KeyObject'
-//   }
-// })
+    if (options?.format === 'der') {
+      switch (options.type) {
+        case 'spki':
+          if (this.params.preExportedKeys) {
+            return this.params.preExportedKeys.spki.der
+          }
+          break
+        case 'pkcs8':
+          if (this.params.preExportedKeys) {
+            return this.params.preExportedKeys.pkcs8.der
+          }
+          break
+        case 'sec1':
+          if (this.params.preExportedKeys) {
+            return this.params.preExportedKeys.sec1.der
+          }
+          break
+        case 'pkcs1':
+          if (this.params.preExportedKeys) {
+            return this.params.preExportedKeys.pkcs1.der
+          }
+        default:
+          throw new Error('Unsupported export type')
+      }
+    }
 
-// export { KeyObject }
+    throw new Error('Unsupported export format')
+  }
+}
 
-export { KeyObject } from 'node:crypto'
+export { KeyObject }

--- a/src/lib/crypto/base64UrlDecode.ts
+++ b/src/lib/crypto/base64UrlDecode.ts
@@ -1,0 +1,9 @@
+export function base64UrlDecode(input: string) {
+  let base64 = input.replace(/-/g, '+').replace(/_/g, '/')
+
+  while (base64.length % 4) {
+    base64 += '='
+  }
+
+  return atob(base64)
+}

--- a/src/lib/crypto/createPrivateKey.ts
+++ b/src/lib/crypto/createPrivateKey.ts
@@ -31,7 +31,8 @@ export const createPrivateKey = async (
       (jwk.key_ops as KeyUsage[]) ?? []
     )
 
-    return KeyObject.from(key) as KeyObjectType
+    // @ts-expect-error TODO
+    return KeyObject.from(key)
   }
 
   throw new TypeError('Unsupported key format')

--- a/src/lib/crypto/createPublicKey.ts
+++ b/src/lib/crypto/createPublicKey.ts
@@ -1,9 +1,12 @@
+import { Buffer } from 'node:buffer'
 import type {
   createPublicKey as CreatePublicKey,
   KeyObject as KeyObjectType
 } from 'node:crypto'
+import { base64UrlDecode } from './base64UrlDecode.js'
 import { subtle } from './index.js'
 import { prepareAsymmetricKey } from './internal/prepareAsymmetricKey/index.js'
+import { isAsymmetricKeyType } from './isAsymmetricKeyType.js'
 import { KeyObject } from './KeyObject.js'
 
 export const createPublicKey = async (
@@ -15,6 +18,8 @@ export const createPublicKey = async (
   const jwk = 'jwk' in data ? data.jwk : null
 
   if (format === 'jwk') {
+    console.log(`format: jwk;`)
+
     if (jwk === null) {
       throw new TypeError('ERR_MISSING_VALUE: key.jwk')
     }
@@ -31,11 +36,54 @@ export const createPublicKey = async (
       (jwk.key_ops ?? []) as KeyUsage[]
     )
 
+    const asymmetricKeyType = jwk.kty?.toLowerCase()
+
+    if (!isAsymmetricKeyType(asymmetricKeyType)) {
+      throw new TypeError('ERR_INVALID_ARG_VALUE: key.jwk.kty')
+    }
+
+    const spki = await subtle.exportKey('spki', key)
+    const pkcs8 = await subtle.exportKey('pkcs8', key)
+    const asymmetricKeySize = spki.byteLength
+
+    if (!jwk.n) {
+      throw new TypeError('ERR_MISSING_ARG: key.jwk.n')
+    }
+
+    const res = KeyObject.from(key, {
+      asymmetricKeyType,
+      asymmetricKeySize,
+      asymmetricKeyDetails: {
+        modulusLength: jwk.n.length * 8,
+        publicExponent: BigInt(base64UrlDecode(jwk.e ?? ''))
+      },
+      preExportedKeys: {
+        pkcs1: {
+          pem: '',
+          der: Buffer.alloc(0)
+        },
+        spki: {
+          pem: Buffer.from(spki),
+          der: Buffer.from(spki)
+        },
+        pkcs8: {
+          pem: Buffer.from(pkcs8),
+          der: Buffer.from(pkcs8)
+        },
+        sec1: {
+          pem: '',
+          der: Buffer.alloc(0)
+        },
+        jwk
+      }
+    })
+
     // @ts-expect-error TODO
-    return KeyObject.from(key)
+    return res
   }
 
   if (format === 'spki') {
+    console.log(`format: spki; data: ${data};`)
     const key = await subtle.importKey(
       'spki',
       data,
@@ -46,9 +94,40 @@ export const createPublicKey = async (
       true,
       ['verify']
     )
+    const spki = await subtle.exportKey('spki', key)
+    const pkcs8 = await subtle.exportKey('pkcs8', key)
+    const jwk = await subtle.exportKey('jwk', key)
+
+    const res = KeyObject.from(key, {
+      asymmetricKeyType: 'rsa',
+      asymmetricKeySize: spki.byteLength,
+      asymmetricKeyDetails: {
+        modulusLength: 2048,
+        publicExponent: BigInt(65537)
+      },
+      preExportedKeys: {
+        pkcs1: {
+          pem: '',
+          der: Buffer.alloc(0)
+        },
+        spki: {
+          pem: Buffer.from(spki),
+          der: Buffer.from(spki)
+        },
+        pkcs8: {
+          pem: Buffer.from(pkcs8),
+          der: Buffer.from(pkcs8)
+        },
+        sec1: {
+          pem: '',
+          der: Buffer.alloc(0)
+        },
+        jwk
+      }
+    })
 
     // @ts-expect-error TODO
-    return KeyObject.from(key)
+    return res
   }
 
   throw new TypeError('Unsupported key format')

--- a/src/lib/crypto/createPublicKey.ts
+++ b/src/lib/crypto/createPublicKey.ts
@@ -31,7 +31,8 @@ export const createPublicKey = async (
       (jwk.key_ops ?? []) as KeyUsage[]
     )
 
-    return KeyObject.from(key) as KeyObjectType
+    // @ts-expect-error TODO
+    return KeyObject.from(key)
   }
 
   if (format === 'spki') {
@@ -46,7 +47,8 @@ export const createPublicKey = async (
       ['verify']
     )
 
-    return KeyObject.from(key) as KeyObjectType
+    // @ts-expect-error TODO
+    return KeyObject.from(key)
   }
 
   throw new TypeError('Unsupported key format')

--- a/src/lib/crypto/isAsymmetricKeyType.ts
+++ b/src/lib/crypto/isAsymmetricKeyType.ts
@@ -1,0 +1,14 @@
+import { AsymmetricKeyType } from './AsymmetricKeyType.js'
+
+export const isAsymmetricKeyType = (val: unknown): val is AsymmetricKeyType =>
+  typeof val === 'string' &&
+  [
+    'rsa',
+    'rsa-pss',
+    'dsa',
+    'ec',
+    'ed25519',
+    'ed448',
+    'x25519',
+    'x448'
+  ].includes(val)


### PR DESCRIPTION
This pull request includes several commits that implement the KeyObject class and related functions. The commits refactor key type checks and exports, add a workaround, and implement the KeyObject class. The KeyObject class is used to create public keys and supports formats such as JWK and SPKI. The commits also include various utility functions for working with keys, such as base64UrlDecode and isAsymmetricKeyType. Overall, this pull request adds functionality for working with cryptographic keys in a more efficient and streamlined manner.