### PR TITLE
Refactor createPublicKey.ts to optimize exportKey calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jill64/cf-auth0.git",
-    "image": "https://opengraph.githubassets.com/2148bc6f7fc68bb80b842cc3b7b5239869567abaa00577dec07b35ff2c461e81/jill64/cf-auth0"
+    "image": "https://opengraph.githubassets.com/c15f185813158f33bcacd0902a20d5d8cc972069b65a43001fc62737ea8b8ffa/jill64/cf-auth0"
   },
   "description": "Auth0 on Cloudflare Pages",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jill64/cf-auth0",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/jsonwebtoken/esm/verify.ts
+++ b/src/jsonwebtoken/esm/verify.ts
@@ -76,7 +76,8 @@ export default async function (
 
   try {
     secretOrPublicKey2 = await createPublicKey(sig)
-  } catch {
+  } catch (err) {
+    console.error('[CreatePublicKey Error]: ', err)
     try {
       secretOrPublicKey2 = createSecretKey(sig as NodeJS.ArrayBufferView)
     } catch {

--- a/src/lib/crypto/createPublicKey.ts
+++ b/src/lib/crypto/createPublicKey.ts
@@ -43,7 +43,6 @@ export const createPublicKey = async (
     }
 
     const spki = await subtle.exportKey('spki', key)
-    const pkcs8 = await subtle.exportKey('pkcs8', key)
     const asymmetricKeySize = spki.byteLength
 
     if (!jwk.n) {
@@ -67,8 +66,8 @@ export const createPublicKey = async (
           der: Buffer.from(spki)
         },
         pkcs8: {
-          pem: Buffer.from(pkcs8),
-          der: Buffer.from(pkcs8)
+          pem: '',
+          der: Buffer.from('')
         },
         sec1: {
           pem: '',
@@ -95,7 +94,6 @@ export const createPublicKey = async (
       ['verify']
     )
     const spki = await subtle.exportKey('spki', key)
-    const pkcs8 = await subtle.exportKey('pkcs8', key)
     const jwk = await subtle.exportKey('jwk', key)
 
     const res = KeyObject.from(key, {
@@ -115,8 +113,8 @@ export const createPublicKey = async (
           der: Buffer.from(spki)
         },
         pkcs8: {
-          pem: Buffer.from(pkcs8),
-          der: Buffer.from(pkcs8)
+          pem: '',
+          der: Buffer.from('')
         },
         sec1: {
           pem: '',


### PR DESCRIPTION
This pull request refactors the `createPublicKey.ts` file to remove unnecessary `exportKey` calls and updates the `KeyObject` class. Additionally, the `verify.ts` file is refactored to handle errors when creating a public key.