### PR TITLE
Refactor createKeyVerifier and KeyObject.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # @jill64/cf-auth0
 
-
 <!----- BEGIN GHOST DOCS BADGES ----->
-<a href="https://npmjs.com/package/@jill64/cf-auth0"><img src="https://img.shields.io/npm/v/@jill64/cf-auth0" alt="npm-version" /></a> <a href="https://npmjs.com/package/@jill64/cf-auth0"><img src="https://img.shields.io/npm/l/@jill64/cf-auth0" alt="npm-license" /></a> <a href="https://npmjs.com/package/@jill64/cf-auth0"><img src="https://img.shields.io/npm/dm/@jill64/cf-auth0" alt="npm-download-month" /></a> <a href="https://npmjs.com/package/@jill64/cf-auth0"><img src="https://img.shields.io/bundlephobia/min/@jill64/cf-auth0" alt="npm-min-size" /></a> <a href="https://github.com/jill64/cf-auth0/actions/workflows/ci.yml"><img src="https://github.com/jill64/cf-auth0/actions/workflows/ci.yml/badge.svg" alt="ci.yml" /></a>
-<!----- END GHOST DOCS BADGES ----->
 
+<a href="https://npmjs.com/package/@jill64/cf-auth0"><img src="https://img.shields.io/npm/v/@jill64/cf-auth0" alt="npm-version" /></a> <a href="https://npmjs.com/package/@jill64/cf-auth0"><img src="https://img.shields.io/npm/l/@jill64/cf-auth0" alt="npm-license" /></a> <a href="https://npmjs.com/package/@jill64/cf-auth0"><img src="https://img.shields.io/npm/dm/@jill64/cf-auth0" alt="npm-download-month" /></a> <a href="https://npmjs.com/package/@jill64/cf-auth0"><img src="https://img.shields.io/bundlephobia/min/@jill64/cf-auth0" alt="npm-min-size" /></a> <a href="https://github.com/jill64/cf-auth0/actions/workflows/ci.yml"><img src="https://github.com/jill64/cf-auth0/actions/workflows/ci.yml/badge.svg" alt="ci.yml" /></a>
+
+<!----- END GHOST DOCS BADGES ----->
 
 Auth0 on Cloudflare Pages
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # @jill64/cf-auth0
 
+
 <!----- BEGIN GHOST DOCS BADGES ----->
-
 <a href="https://npmjs.com/package/@jill64/cf-auth0"><img src="https://img.shields.io/npm/v/@jill64/cf-auth0" alt="npm-version" /></a> <a href="https://npmjs.com/package/@jill64/cf-auth0"><img src="https://img.shields.io/npm/l/@jill64/cf-auth0" alt="npm-license" /></a> <a href="https://npmjs.com/package/@jill64/cf-auth0"><img src="https://img.shields.io/npm/dm/@jill64/cf-auth0" alt="npm-download-month" /></a> <a href="https://npmjs.com/package/@jill64/cf-auth0"><img src="https://img.shields.io/bundlephobia/min/@jill64/cf-auth0" alt="npm-min-size" /></a> <a href="https://github.com/jill64/cf-auth0/actions/workflows/ci.yml"><img src="https://github.com/jill64/cf-auth0/actions/workflows/ci.yml/badge.svg" alt="ci.yml" /></a>
-
 <!----- END GHOST DOCS BADGES ----->
+
 
 Auth0 on Cloudflare Pages
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jill64/cf-auth0",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jill64/cf-auth0.git",
-    "image": "https://opengraph.githubassets.com/c15f185813158f33bcacd0902a20d5d8cc972069b65a43001fc62737ea8b8ffa/jill64/cf-auth0"
+    "image": "https://opengraph.githubassets.com/e18822b272cf659049dad500fab5a9e8ea13b16d12163e9769b1986baf0ce15e/jill64/cf-auth0"
   },
   "description": "Auth0 on Cloudflare Pages",
   "publishConfig": {

--- a/src/jwa/esm/index.ts
+++ b/src/jwa/esm/index.ts
@@ -189,7 +189,7 @@ const createKeyVerifier =
   ) => {
     checkIsPublicKey(publicKey)
     const thing2 = normalizeInput(thing)
-    const signature2 = toBase64(signature)
+    const signature2 = Buffer.from(signature).toString('base64')
     const verifier = createVerify('RSA-SHA' + bits)
 
     verifier.update(thing2)

--- a/src/lib/crypto/KeyObject.ts
+++ b/src/lib/crypto/KeyObject.ts
@@ -76,6 +76,8 @@ class KeyObject implements KeyObjectType {
       configurable: false,
       writable: false
     })
+
+    this.export = this.export.bind(this)
   }
 
   static from = (key: CryptoKey, params: KeyObjectParams) =>


### PR DESCRIPTION
Refactor the `createKeyVerifier` function to use `Buffer.from` instead of `toBase64` for signature conversion. Additionally, refactor `KeyObject.ts` to bind the `export` method.