### PR TITLE
Refactor CSRF state generation and update Svelte version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@playwright/test": "1.49.1",
     "@sveltejs/adapter-cloudflare": "5.0.0",
     "@sveltejs/kit": "2.15.1",
-    "svelte": "5.16.0",
+    "svelte": "5.16.1",
     "typescript": "5.7.2",
     "vite": "6.0.6",
     "vitest": "2.1.8",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     "test": "vitest",
     "test:e2e": "playwright test"
   },
-  "peerDependencies": {
-    "svelte": "^5.0.0"
-  },
   "devDependencies": {
     "@jill64/eslint-config-svelte": "2.0.2",
     "@jill64/npm-demo-layout": "2.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,10 +38,10 @@ importers:
         version: 4.20241230.0
       '@jill64/eslint-config-svelte':
         specifier: 2.0.2
-        version: 2.0.2(svelte@5.16.0)(typescript@5.7.2)
+        version: 2.0.2(svelte@5.16.1)(typescript@5.7.2)
       '@jill64/npm-demo-layout':
         specifier: 2.0.7
-        version: 2.0.7(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
+        version: 2.0.7(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
       '@jill64/playwright-config':
         specifier: 2.4.2
         version: 2.4.2(@playwright/test@1.49.1)
@@ -50,7 +50,7 @@ importers:
         version: 1.0.0
       '@jill64/sentry-sveltekit-cloudflare':
         specifier: 2.0.1
-        version: 2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
+        version: 2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
       '@jill64/universal-sanitizer':
         specifier: 1.3.6
         version: 1.3.6
@@ -59,13 +59,13 @@ importers:
         version: 1.49.1
       '@sveltejs/adapter-cloudflare':
         specifier: 5.0.0
-        version: 5.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(wrangler@3.99.0(@cloudflare/workers-types@4.20241230.0))
+        version: 5.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(wrangler@3.99.0(@cloudflare/workers-types@4.20241230.0))
       '@sveltejs/kit':
         specifier: 2.15.1
-        version: 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
+        version: 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: 5.0.3
-        version: 5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
+        version: 5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
       '@types/jws':
         specifier: 3.2.10
         version: 3.2.10
@@ -88,8 +88,8 @@ importers:
         specifier: 16.4.7
         version: 16.4.7
       svelte:
-        specifier: 5.16.0
-        version: 5.16.0
+        specifier: 5.16.1
+        version: 5.16.1
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -1875,8 +1875,8 @@ packages:
     resolution: {integrity: sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==}
     engines: {node: '>= 8'}
 
-  svelte@5.16.0:
-    resolution: {integrity: sha512-Ygqsiac6UogVED2ruKclU+pOeMThxWtp9LG+li7BXeDKC2paVIsRTMkNmcON4Zejerd1s5sZHWx6ZtU85xklVg==}
+  svelte@5.16.1:
+    resolution: {integrity: sha512-FsA1OjAKMAFSDob6j/Tv2ZV9rY4SeqPd1WXQlQkFkePAozSHLp6tbkU9qa1xJ+uTRzMSM2Vx3USdsYZBXd3H3g==}
     engines: {node: '>=18'}
 
   tiny-glob@0.2.9:
@@ -2439,7 +2439,7 @@ snapshots:
 
   '@jill64/attempt@1.1.3': {}
 
-  '@jill64/eslint-config-svelte@2.0.2(svelte@5.16.0)(typescript@5.7.2)':
+  '@jill64/eslint-config-svelte@2.0.2(svelte@5.16.1)(typescript@5.7.2)':
     dependencies:
       '@eslint/js': 9.17.0
       '@types/eslint': 9.6.1
@@ -2447,27 +2447,27 @@ snapshots:
       '@typescript-eslint/parser': 8.19.0(eslint@9.17.0)(typescript@5.7.2)
       eslint: 9.17.0
       eslint-config-prettier: 9.1.0(eslint@9.17.0)
-      eslint-plugin-svelte: 2.46.1(eslint@9.17.0)(svelte@5.16.0)
-      svelte: 5.16.0
-      svelte-eslint-parser: 0.43.0(svelte@5.16.0)
+      eslint-plugin-svelte: 2.46.1(eslint@9.17.0)(svelte@5.16.1)
+      svelte: 5.16.1
+      svelte-eslint-parser: 0.43.0(svelte@5.16.1)
     transitivePeerDependencies:
       - jiti
       - supports-color
       - ts-node
       - typescript
 
-  '@jill64/npm-demo-layout@2.0.7(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)':
+  '@jill64/npm-demo-layout@2.0.7(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)':
     dependencies:
-      '@jill64/svelte-dark-theme': 5.1.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
-      '@jill64/svelte-menu': 2.0.0(svelte@5.16.0)
-      '@jill64/svelte-ogp': 2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
-      '@jill64/svelte-sanitize': 2.1.0(svelte@5.16.0)
-      '@jill64/svelte-toast': 2.1.5(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
-      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
-      svelte: 5.16.0
-      svelte-code-copy: 2.2.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
+      '@jill64/svelte-dark-theme': 5.1.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
+      '@jill64/svelte-menu': 2.0.0(svelte@5.16.1)
+      '@jill64/svelte-ogp': 2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
+      '@jill64/svelte-sanitize': 2.1.0(svelte@5.16.1)
+      '@jill64/svelte-toast': 2.1.5(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
+      svelte: 5.16.1
+      svelte-code-copy: 2.2.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
       svelte-highlight: 7.8.2
-      svelte-highlight-switcher: 1.3.3(svelte-highlight@7.8.2)(svelte@5.16.0)
+      svelte-highlight-switcher: 1.3.3(svelte-highlight@7.8.2)(svelte@5.16.1)
 
   '@jill64/playwright-config@2.4.2(@playwright/test@1.49.1)':
     dependencies:
@@ -2475,68 +2475,68 @@ snapshots:
 
   '@jill64/prettier-config@1.0.0': {}
 
-  '@jill64/sentry-sveltekit-cloudflare@2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)':
+  '@jill64/sentry-sveltekit-cloudflare@2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)':
     dependencies:
-      '@sentry/svelte': 8.47.0(svelte@5.16.0)
-      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
+      '@sentry/svelte': 8.47.0(svelte@5.16.1)
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
       toucan-js: 4.0.0
     transitivePeerDependencies:
       - svelte
 
-  '@jill64/svelte-dark-theme@5.1.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)':
+  '@jill64/svelte-dark-theme@5.1.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)':
     dependencies:
-      '@jill64/svelte-device-theme': 2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
-      '@jill64/svelte-html': 2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
-      '@jill64/svelte-storage': 2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
-      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
-      svelte: 5.16.0
-      svelte-baked-cookie: 2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
+      '@jill64/svelte-device-theme': 2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
+      '@jill64/svelte-html': 2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
+      '@jill64/svelte-storage': 2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
+      svelte: 5.16.1
+      svelte-baked-cookie: 2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
       svelte-feather-icons: 4.2.0
       typescanner: 0.5.3
 
-  '@jill64/svelte-device-theme@2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)':
+  '@jill64/svelte-device-theme@2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)':
     dependencies:
-      svelte: 5.16.0
-      svelte-mq-store: 3.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
+      svelte: 5.16.1
+      svelte-mq-store: 3.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
     transitivePeerDependencies:
       - '@sveltejs/kit'
 
-  '@jill64/svelte-html@2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)':
+  '@jill64/svelte-html@2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)':
     dependencies:
-      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
-      svelte: 5.16.0
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
+      svelte: 5.16.1
 
-  '@jill64/svelte-menu@2.0.0(svelte@5.16.0)':
+  '@jill64/svelte-menu@2.0.0(svelte@5.16.1)':
     dependencies:
-      svelte: 5.16.0
+      svelte: 5.16.1
 
-  '@jill64/svelte-observer@0.0.1(svelte@5.16.0)':
+  '@jill64/svelte-observer@0.0.1(svelte@5.16.1)':
     dependencies:
-      svelte: 5.16.0
+      svelte: 5.16.1
 
-  '@jill64/svelte-ogp@2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)':
+  '@jill64/svelte-ogp@2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)':
     dependencies:
-      '@jill64/svelte-html': 2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
-      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
-      svelte: 5.16.0
+      '@jill64/svelte-html': 2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
+      svelte: 5.16.1
 
-  '@jill64/svelte-sanitize@2.1.0(svelte@5.16.0)':
+  '@jill64/svelte-sanitize@2.1.0(svelte@5.16.1)':
     dependencies:
       '@jill64/universal-sanitizer': 1.3.6
-      svelte: 5.16.0
+      svelte: 5.16.1
 
-  '@jill64/svelte-storage@2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)':
+  '@jill64/svelte-storage@2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)':
     dependencies:
       '@jill64/typed-storage': 3.1.5
-      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
-      svelte: 5.16.0
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
+      svelte: 5.16.1
 
-  '@jill64/svelte-toast@2.1.5(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)':
+  '@jill64/svelte-toast@2.1.5(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)':
     dependencies:
-      '@jill64/svelte-device-theme': 2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
-      svelte: 5.16.0
-      svelte-french-toast: 1.2.0(svelte@5.16.0)
-      svelte-mq-store: 3.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
+      '@jill64/svelte-device-theme': 2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
+      svelte: 5.16.1
+      svelte-french-toast: 1.2.0(svelte@5.16.1)
+      svelte-mq-store: 3.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
     transitivePeerDependencies:
       - '@sveltejs/kit'
 
@@ -2683,12 +2683,12 @@ snapshots:
       '@sentry/types': 8.9.2
       '@sentry/utils': 8.9.2
 
-  '@sentry/svelte@8.47.0(svelte@5.16.0)':
+  '@sentry/svelte@8.47.0(svelte@5.16.1)':
     dependencies:
       '@sentry/browser': 8.47.0
       '@sentry/core': 8.47.0
       magic-string: 0.30.17
-      svelte: 5.16.0
+      svelte: 5.16.1
 
   '@sentry/types@8.9.2': {}
 
@@ -2696,17 +2696,17 @@ snapshots:
     dependencies:
       '@sentry/types': 8.9.2
 
-  '@sveltejs/adapter-cloudflare@5.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(wrangler@3.99.0(@cloudflare/workers-types@4.20241230.0))':
+  '@sveltejs/adapter-cloudflare@5.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(wrangler@3.99.0(@cloudflare/workers-types@4.20241230.0))':
     dependencies:
       '@cloudflare/workers-types': 4.20241230.0
-      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
       esbuild: 0.24.2
       worktop: 0.8.0-next.18
       wrangler: 3.99.0(@cloudflare/workers-types@4.20241230.0)
 
-  '@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))':
+  '@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -2718,27 +2718,27 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.7.1
       sirv: 3.0.0
-      svelte: 5.16.0
+      svelte: 5.16.1
       tiny-glob: 0.2.9
       vite: 6.0.6(@types/node@22.10.2)
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
       debug: 4.4.0
-      svelte: 5.16.0
+      svelte: 5.16.1
       vite: 6.0.6(@types/node@22.10.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
-      svelte: 5.16.0
+      svelte: 5.16.1
       vite: 6.0.6(@types/node@22.10.2)
       vitefu: 1.0.4(vite@6.0.6(@types/node@22.10.2))
     transitivePeerDependencies:
@@ -3161,7 +3161,7 @@ snapshots:
     dependencies:
       eslint: 9.17.0
 
-  eslint-plugin-svelte@2.46.1(eslint@9.17.0)(svelte@5.16.0):
+  eslint-plugin-svelte@2.46.1(eslint@9.17.0)(svelte@5.16.1):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0)
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -3174,9 +3174,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       semver: 7.6.3
-      svelte-eslint-parser: 0.43.0(svelte@5.16.0)
+      svelte-eslint-parser: 0.43.0(svelte@5.16.1)
     optionalDependencies:
-      svelte: 5.16.0
+      svelte: 5.16.1
     transitivePeerDependencies:
       - ts-node
 
@@ -3694,25 +3694,25 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-baked-cookie@2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0):
+  svelte-baked-cookie@2.0.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1):
     dependencies:
       '@jill64/transform': 1.0.4
-      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
       '@types/cookie': 1.0.0
       cookie: 1.0.2
-      svelte: 5.16.0
+      svelte: 5.16.1
       ts-serde: 1.0.8
 
-  svelte-code-copy@2.2.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0):
+  svelte-code-copy@2.2.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1):
     dependencies:
-      '@jill64/svelte-observer': 0.0.1(svelte@5.16.0)
-      svelte: 5.16.0
+      '@jill64/svelte-observer': 0.0.1(svelte@5.16.1)
+      svelte: 5.16.1
       svelte-feather-icons: 4.2.0
-      svelte-hydrated: 2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
+      svelte-hydrated: 2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)
     transitivePeerDependencies:
       - '@sveltejs/kit'
 
-  svelte-eslint-parser@0.43.0(svelte@5.16.0):
+  svelte-eslint-parser@0.43.0(svelte@5.16.1):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -3720,43 +3720,43 @@ snapshots:
       postcss: 8.4.49
       postcss-scss: 4.0.9(postcss@8.4.49)
     optionalDependencies:
-      svelte: 5.16.0
+      svelte: 5.16.1
 
   svelte-feather-icons@4.2.0:
     dependencies:
       svelte: 3.59.2
 
-  svelte-french-toast@1.2.0(svelte@5.16.0):
+  svelte-french-toast@1.2.0(svelte@5.16.1):
     dependencies:
-      svelte: 5.16.0
-      svelte-writable-derived: 3.1.1(svelte@5.16.0)
+      svelte: 5.16.1
+      svelte-writable-derived: 3.1.1(svelte@5.16.1)
 
-  svelte-highlight-switcher@1.3.3(svelte-highlight@7.8.2)(svelte@5.16.0):
+  svelte-highlight-switcher@1.3.3(svelte-highlight@7.8.2)(svelte@5.16.1):
     dependencies:
-      svelte: 5.16.0
+      svelte: 5.16.1
       svelte-highlight: 7.8.2
 
   svelte-highlight@7.8.2:
     dependencies:
       highlight.js: 11.11.1
 
-  svelte-hydrated@2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0):
+  svelte-hydrated@2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1):
     dependencies:
-      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
-      svelte: 5.16.0
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
+      svelte: 5.16.1
 
-  svelte-mq-store@3.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0):
+  svelte-mq-store@3.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1):
     dependencies:
-      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
-      svelte: 5.16.0
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.1)(vite@6.0.6(@types/node@22.10.2))
+      svelte: 5.16.1
 
-  svelte-writable-derived@3.1.1(svelte@5.16.0):
+  svelte-writable-derived@3.1.1(svelte@5.16.1):
     dependencies:
-      svelte: 5.16.0
+      svelte: 5.16.1
 
   svelte@3.59.2: {}
 
-  svelte@5.16.0:
+  svelte@5.16.1:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,6 +5,7 @@ import {
 import { getToken, setAuthCookie, verifyToken } from '$lib/server/auth/auth0'
 import * as jwt from '$lib/server/auth/jsonwebtoken'
 import type { Cookies } from '@sveltejs/kit'
+import crypto from 'node:crypto'
 
 export class CfAuth0 {
   private auth0ClientId
@@ -97,7 +98,7 @@ export class CfAuth0 {
     /** @description current location */
     url: URL
   }) {
-    const csrfState = Math.random().toString(36).substring(7)
+    const csrfState = crypto.randomBytes(16).toString('hex')
 
     cookies.set('csrfState', csrfState, {
       httpOnly: true,


### PR DESCRIPTION
Refactor the CSRF state generation to use a more secure method with the crypto module. Update Svelte to version 5.16.1 and remove unnecessary peerDependencies from package.json.